### PR TITLE
Added testcases for Integration Testing

### DIFF
--- a/wfos_ics/wfos-bgrxassembly/src/test/resources/wfosContainer.conf
+++ b/wfos_ics/wfos-bgrxassembly/src/test/resources/wfosContainer.conf
@@ -1,0 +1,33 @@
+name = "WfosContainer"
+components: [
+  {
+    prefix = "wfos.bgrxAssembly"
+    componentType = assembly
+    componentHandlerClassName = "wfos.bgrxassembly.BgrxassemblyHandlers"
+    locationServiceUsage = RegisterAndTrackServices
+    connections = [
+      {
+        prefix: "wfos.rgriphcd"
+        componentType: hcd
+        connectionType: akka
+      },
+      {
+        prefix: "wfos.lgriphcd"
+        componentType: hcd
+        connectionType: akka
+      }
+    ]
+  },
+  {
+    prefix = "wfos.rgriphcd"
+    componentType = hcd
+    componentHandlerClassName = "wfos.rgriphcd.RgriphcdHandlers"
+    locationServiceUsage = RegisterOnly
+  },
+  {
+    prefix = "wfos.lgriphcd"
+    componentType = hcd
+    componentHandlerClassName = "wfos.lgriphcd.LgriphcdHandlers"
+    locationServiceUsage = RegisterOnly
+  }
+]


### PR DESCRIPTION
Added testcases as part of Integration testing in the wfos-bgrassembly. 
WfosContainer.conf is used as the configuration file to spawn the container and the wfosContainerTest.scala contains the testcases.
Also some minor changes in the code for better readability